### PR TITLE
SoundLogo#546: Add description field and controls for CTA button styling

### DIFF
--- a/assets/src/editor/blocks/landing-page-hero/index.js
+++ b/assets/src/editor/blocks/landing-page-hero/index.js
@@ -131,7 +131,7 @@ export const settings = {
 
 		const blockProps = useBlockProps( { className: 'hero' } );
 
-		const ctaButtonAdditionalClass = ctaButtonStyle ? `hero__cta-button hero__cta-button--${ ctaButtonStyle }` : '';
+		const ctaButtonAdditionalClass = ctaButtonStyle ? ` hero__cta-button hero__cta-button--${ ctaButtonStyle }` : '';
 
 		return (
 			<div { ...applyDefaultStyle( blockProps ) } >
@@ -173,19 +173,17 @@ export const settings = {
 							value={ title }
 							onChange={ title => setAttributes( { title } ) }
 						/>
-						{ description && (
-							<RichText
-								className="hero__description"
-								keepPlaceholderOnFocus
-								multiline="p"
-								placeholder={ __( 'Description text - some additional information on the hero header.', 'shiro-admin' ) }
-								tagName="div"
-								value={ description }
-								onChange={ description => setAttributes( { description } ) }
-							/>
-						) }
+						<RichText
+							className="hero__description"
+							keepPlaceholderOnFocus
+							multiline="p"
+							placeholder={ __( 'Description text - some additional information on the hero header.', 'shiro-admin' ) }
+							tagName="div"
+							value={ description }
+							onChange={ description => setAttributes( { description } ) }
+						/>
 						<Cta
-							className={ `hero__call-to-action cta-button ${ ctaButtonStyle }` }
+							className={ `hero__call-to-action cta-button${ ctaButtonStyle }` }
 							text={ buttonText }
 							url={ buttonLink }
 							onChangeLink={ buttonLink => setAttributes( { buttonLink } ) }
@@ -245,7 +243,7 @@ export const settings = {
 
 		const blockProps = useBlockProps.save( { className: 'hero' } );
 
-		const ctaButtonAdditionalClass = ctaButtonStyle ? `hero__cta-button hero__cta-button--${ ctaButtonStyle }` : '';
+		const ctaButtonAdditionalClass = ctaButtonStyle ? ` hero__cta-button hero__cta-button--${ ctaButtonStyle }` : '';
 
 		return (
 			<div { ...applyDefaultStyle( blockProps ) }>
@@ -271,7 +269,7 @@ export const settings = {
 						) }
 						{ buttonLink && (
 							<a
-								className={ `hero__call-to-action cta-button ${ ctaButtonAdditionalClass }` }
+								className={ `hero__call-to-action cta-button${ ctaButtonAdditionalClass }` }
 								href={ buttonLink }
 							>
 								{ buttonText }

--- a/assets/src/editor/blocks/landing-page-hero/index.js
+++ b/assets/src/editor/blocks/landing-page-hero/index.js
@@ -10,6 +10,7 @@ import {
 	useBlockProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
+import { SelectControl, Panel, PanelBody, } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -20,7 +21,6 @@ import ImageFilter, { DEFAULT_IMAGE_FILTER } from '../../components/image-filter
 import ImagePicker from '../../components/image-picker';
 import blockStyles, { applyDefaultStyle } from '../../helpers/block-styles';
 import './style.scss';
-import { SelectControl, Panel, PanelBody, } from '@wordpress/components';
 
 export const name = 'shiro/landing-page-hero';
 
@@ -131,6 +131,8 @@ export const settings = {
 
 		const blockProps = useBlockProps( { className: 'hero' } );
 
+		const ctaButtonAdditionalClass = ctaButtonStyle ? `hero__cta-button hero__cta-button--${ ctaButtonStyle }` : '';
+
 		return (
 			<div { ...applyDefaultStyle( blockProps ) } >
 				<InspectorControls key="setting">
@@ -171,17 +173,19 @@ export const settings = {
 							value={ title }
 							onChange={ title => setAttributes( { title } ) }
 						/>
-						<RichText
-							className="hero__description"
-							keepPlaceholderOnFocus
-							multiline="p"
-							placeholder={ __( 'Description text - some additional information on the hero header.', 'shiro-admin' ) }
-							tagName="div"
-							value={ description }
-							onChange={ description => setAttributes( { description } ) }
-						/>
+						{ description && (
+							<RichText
+								className="hero__description"
+								keepPlaceholderOnFocus
+								multiline="p"
+								placeholder={ __( 'Description text - some additional information on the hero header.', 'shiro-admin' ) }
+								tagName="div"
+								value={ description }
+								onChange={ description => setAttributes( { description } ) }
+							/>
+						) }
 						<Cta
-							className={ `hero__call-to-action cta-button hero__cta-button hero__cta-button--${ ctaButtonStyle }` }
+							className={ `hero__call-to-action cta-button ${ ctaButtonStyle }` }
 							text={ buttonText }
 							url={ buttonLink }
 							onChangeLink={ buttonLink => setAttributes( { buttonLink } ) }
@@ -241,6 +245,8 @@ export const settings = {
 
 		const blockProps = useBlockProps.save( { className: 'hero' } );
 
+		const ctaButtonAdditionalClass = ctaButtonStyle ? `hero__cta-button hero__cta-button--${ ctaButtonStyle }` : '';
+
 		return (
 			<div { ...applyDefaultStyle( blockProps ) }>
 				<header className="hero__header">
@@ -255,15 +261,17 @@ export const settings = {
 							tagName="h1"
 							value={ title }
 						/>
-						<RichText.Content
-							className="hero__description"
-							multiline="p"
-							tagName="div"
-							value={ description }
-						/>
+						{ description && (
+							<RichText.Content
+								className="hero__description"
+								multiline="p"
+								tagName="div"
+								value={ description }
+							/>
+						) }
 						{ buttonLink && (
 							<a
-								className={ `hero__call-to-action cta-button hero__cta-button hero__cta-button--${ ctaButtonStyle }` }
+								className={ `hero__call-to-action cta-button ${ ctaButtonAdditionalClass }` }
 								href={ buttonLink }
 							>
 								{ buttonText }

--- a/assets/src/editor/blocks/landing-page-hero/index.js
+++ b/assets/src/editor/blocks/landing-page-hero/index.js
@@ -5,7 +5,11 @@
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	InspectorControls,
+} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,6 +20,7 @@ import ImageFilter, { DEFAULT_IMAGE_FILTER } from '../../components/image-filter
 import ImagePicker from '../../components/image-picker';
 import blockStyles, { applyDefaultStyle } from '../../helpers/block-styles';
 import './style.scss';
+import { SelectControl, Panel, PanelBody, } from '@wordpress/components';
 
 export const name = 'shiro/landing-page-hero';
 
@@ -39,10 +44,12 @@ export const settings = {
 		attributes: {
 			kicker: __( 'Our Work', 'shiro-admin' ),
 			title: __( 'We help everyone share in the sum of all knowledge', 'shiro-admin' ),
+			description: __( 'People all over the world ask their voice-activated devices all sorts of questions, and search engines query Wikipedia knowledge to provide them with answers. That is why we are looking to co-create a sound logo that will be played each time a person is served an answer to a question that was responded with Wikimedia projects.', 'shiro-admin' ),
 			pageIntro: __( 'We are the people who keep knowledge free. There is an amazing community of people around the world that makes great projects like Wikipedia. We help them do that work. We take care of the technical infrastructure, the legal challenges, and the growing pains.', 'shiro-admin' ),
 			imageUrl: 'https://s.w.org/images/core/5.3/MtBlanc1.jpg',
 			buttonText: 'Learn More',
 			buttonLink: 'https://wikimediafoundation.org/',
+			ctaButtonStyle: 'no-icon-blue-background',
 		},
 	},
 
@@ -93,6 +100,16 @@ export const settings = {
 			selector: '.hero__intro',
 			multiline: 'p',
 		},
+		description: {
+			type: 'string',
+			source: 'html',
+			selector: '.hero__description',
+			multiline: 'p',
+		},
+		ctaButtonStyle: {
+			type: 'string',
+			default: 'no-icon-blue-background',
+		},
 	},
 
 	/**
@@ -106,14 +123,36 @@ export const settings = {
 			imageUrl,
 			buttonText,
 			buttonLink,
+			description,
 			pageIntro,
 			imageFilter,
+			ctaButtonStyle,
 		} = attributes;
 
 		const blockProps = useBlockProps( { className: 'hero' } );
 
 		return (
 			<div { ...applyDefaultStyle( blockProps ) } >
+				<InspectorControls key="setting">
+					<Panel>
+						<PanelBody
+							title={ __( 'Call-to-action button', 'shiro-admin' ) }
+							initialOpen={ true }
+						>
+							<SelectControl
+								label={ __( 'Button style', 'shiro-admin' ) }
+								value={ ctaButtonStyle }
+								options={ [
+									{ label: __( 'No icon / Blue background', 'shiro-admin' ), value: 'no-icon-blue-background' },
+									{ label: __( 'Info icon / Gray background', 'shiro-admin' ), value: 'info-icon-gray-background' },
+									{ label: __( 'Info icon / No background', 'shiro-admin' ), value: 'info-icon-no-background' },
+									{ label: __( 'Expand icon / Gray background', 'shiro-admin' ), value: 'expand-icon-gray-background' },
+								] }
+								onChange={ ( value ) => setAttributes( { ctaButtonStyle: value } ) }
+							/>
+						</PanelBody>
+					</Panel>
+				</InspectorControls>
 				<header className="hero__header">
 					<div className="hero__text-column">
 						<RichText
@@ -132,8 +171,17 @@ export const settings = {
 							value={ title }
 							onChange={ title => setAttributes( { title } ) }
 						/>
+						<RichText
+							className="hero__description"
+							keepPlaceholderOnFocus
+							multiline="p"
+							placeholder={ __( 'Description text - some additional information on the hero header.', 'shiro-admin' ) }
+							tagName="div"
+							value={ description }
+							onChange={ description => setAttributes( { description } ) }
+						/>
 						<Cta
-							className="hero__call-to-action cta-button"
+							className={ `hero__call-to-action cta-button hero__cta-button hero__cta-button--${ ctaButtonStyle }` }
 							text={ buttonText }
 							url={ buttonLink }
 							onChangeLink={ buttonLink => setAttributes( { buttonLink } ) }
@@ -185,8 +233,10 @@ export const settings = {
 			imageUrl,
 			buttonText,
 			buttonLink,
+			description,
 			pageIntro,
 			imageFilter,
+			ctaButtonStyle,
 		} = attributes;
 
 		const blockProps = useBlockProps.save( { className: 'hero' } );
@@ -205,9 +255,15 @@ export const settings = {
 							tagName="h1"
 							value={ title }
 						/>
+						<RichText.Content
+							className="hero__description"
+							multiline="p"
+							tagName="div"
+							value={ description }
+						/>
 						{ buttonLink && (
 							<a
-								className="hero__call-to-action cta-button"
+								className={ `hero__call-to-action cta-button hero__cta-button hero__cta-button--${ ctaButtonStyle }` }
 								href={ buttonLink }
 							>
 								{ buttonText }

--- a/assets/src/sass/blocks/_landing-page-hero.scss
+++ b/assets/src/sass/blocks/_landing-page-hero.scss
@@ -137,7 +137,7 @@
 		&--info-icon-gray-background {
 			color: #000 !important;
 			background-color: #F4F4F4;
-			background-image: url("../assets/src/svg/individual/info.svg");
+			background-image: url("../../../../assets/src/svg/individual/info.svg");
 
 			&:hover {
 				color: #000 !important;
@@ -149,7 +149,7 @@
 			color: #FFF !important;
 			background-color: transparent;
 			border: 2px solid white;
-			background-image: url("../assets/src/svg/individual/info.svg");
+			background-image: url("../../../../assets/src/svg/individual/info.svg");
 
 			&:hover {
 				color: #FFF !important;
@@ -160,7 +160,7 @@
 		&--expand-icon-gray-background {
 			color: #000 !important;
 			background-color: #F4F4F4;
-			background-image: url("../assets/src/svg/individual/downTriangle.svg");
+			background-image: url("../../../../assets/src/svg/individual/downTriangle.svg");
 
 			&:hover {
 				color: #000 !important;

--- a/assets/src/sass/blocks/_landing-page-hero.scss
+++ b/assets/src/sass/blocks/_landing-page-hero.scss
@@ -110,4 +110,64 @@
 			}
 		}
 	}
+
+	&__description p:empty {
+		display: none;
+	}
+
+	&__cta-button {
+		background-position-x: 15px;
+		background-position-y: center;
+		background-repeat: no-repeat;
+		height: 44px;
+		line-height: 30px;
+		padding-left: 60px;
+		padding-right: 30px;
+		width: auto;
+
+		&--no-icon-blue-background {
+			// Reaplying current default button settings
+			color: #FFF !important;
+			background-color: #3a25ff;
+			padding: .375rem .75rem;
+			line-height: 1.25rem;
+			height: 34px;
+		}
+
+		&--info-icon-gray-background {
+			color: #000 !important;
+			background-color: #F4F4F4;
+			background-image: url("../assets/src/svg/individual/info.svg");
+
+			&:hover {
+				color: #000 !important;
+				background-color: #F4F4F4;
+			}
+		}
+
+		&--info-icon-no-background {
+			color: #FFF !important;
+			background-color: transparent;
+			border: 2px solid white;
+			background-image: url("../assets/src/svg/individual/info.svg");
+
+			&:hover {
+				color: #FFF !important;
+				background-color: transparent;
+			}
+		}
+
+		&--expand-icon-gray-background {
+			color: #000 !important;
+			background-color: #F4F4F4;
+			background-image: url("../assets/src/svg/individual/downTriangle.svg");
+
+			&:hover {
+				color: #000 !important;
+				background-color: #F4F4F4;
+			}
+		}
+	}
 }
+
+


### PR DESCRIPTION
This PR intends to add `description` field and CTA button styling on Landing Page Hero custom block, to support Sound Logo mockups. 

The expectation is not changing the current cta buttons outside Sound Logo project, but that needs to be double-checked before merging this PR.

Related PR on Sound Logo: https://github.com/wpcomvip/wikimediasoundlogo/pull/59