### PR TITLE
Add "down" icon to spritesheet

### DIFF
--- a/assets/src/svg/individual/down.svg
+++ b/assets/src/svg/individual/down.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+	<title>
+		down
+	</title>
+	<path d="M10.085 2.943L6.05 6.803l-3.947-3.86L1.05 3.996l5 5 5-5z"/>
+</svg>


### PR DESCRIPTION
This theme already has a "down" icon, but it wasn't being built into the theme's spritesheet. This change copies it into the "svg/individual" directory, so that it can be built into the svg spritesheet and rendered with the theme helper functions.

See https://github.com/wpcomvip/wikimediasoundlogo/pull/60