### PR TITLE
#594: Remove text shadow from accordion toggles on hover

### DIFF
--- a/assets/src/sass/blocks/_accordion.scss
+++ b/assets/src/sass/blocks/_accordion.scss
@@ -36,10 +36,6 @@
 				transform: rotate(0deg);
 			}
 		}
-
-		&:hover {
-			text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
-		}
 	}
 
 	&__content {


### PR DESCRIPTION
Removes the hover state from the accordion item toggle button, per feedback in https://github.com/humanmade/Wikimedia/issues/594#issuecomment-1230620342.