### PR TITLE
Prevent accordion header from overlapping expand icon

### DIFF
--- a/assets/src/sass/blocks/_accordion.scss
+++ b/assets/src/sass/blocks/_accordion.scss
@@ -20,7 +20,7 @@
 
 		&-text {
 			font-weight: 400;
-			margin-bottom: 0;
+			margin: 0 1.5em 0 0;
 		}
 
 		&::after {


### PR DESCRIPTION
Gives the accordion header text a right margin so that it wraps around the +/x icon.

See https://github.com/humanmade/wikimedia/issues/594