### PR TITLE
Add unstyled "musical-note" icon

### DIFF
--- a/assets/src/svg/individual/musical-note.svg
+++ b/assets/src/svg/individual/musical-note.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24">
+    <path style="clip-rule:evenodd;fill-rule:evenodd;stroke-width:.80088025" d="M12.55 3.186h-2.202v11.21a3.304 3.304 0 1 0 2.203 3.105V6.49h5.506V3.186Z"/>
+</svg>


### PR DESCRIPTION
The previous musical note icon has a fill attribute set on it, which means that it won't work for styling in CSS. This adds another musical note icon without a fill color specified.

Necessary for updating the "Submit" button in the Sound Logo header to use a musical note icon.