### PR TITLE
Define RTL style overrides for accordion block

### DIFF
--- a/assets/src/sass/blocks/_accordion.scss
+++ b/assets/src/sass/blocks/_accordion.scss
@@ -20,15 +20,16 @@
 
 		&-text {
 			font-weight: 400;
-			margin: 0 1.5em 0 0;
+			margin: 0 1.5em 0 0; /*rtl: margin: 0 0 0 1.5em;*/
 		}
 
 		&::after {
 			content: "\d7";
 			display: flex;
 			font-size: 20px;
+			left: unset; /*rtl: 0*/
 			position: absolute;
-			right: 0;
+			right: 0; /*rtl: unset*/
 			transform: rotate(45deg);
 			width: 20px;
 


### PR DESCRIPTION
Reverses the direction of the icon on RTL languages for a consistent reading experience.

See issue report in https://github.com/humanmade/Wikimedia/issues/594#issuecomment-1234752438