### PR TITLE
SL#661: Scroll into view when closing an accordion block or a collapsible text

### DIFF
--- a/assets/src/js/accordion/toggler.js
+++ b/assets/src/js/accordion/toggler.js
@@ -18,6 +18,7 @@ const toggleAccordionItem = e => {
 
 	// Open items should have the empty string as the attribute value.
 	parent.toggleAttribute( 'aria-expanded', isExpanded !== '' );
+	parent.scrollIntoView( { block: 'center' } );
 };
 
 /**

--- a/assets/src/js/collapsible-text.js
+++ b/assets/src/js/collapsible-text.js
@@ -6,10 +6,13 @@
  * Handle a click event on the collapsible area's toggle button.
  *
  * @param {Event} Click event.
- * @returns {HTMLElement} Target element.
  */
-const toggleCollapsibleArea = ( { target } ) =>
-	target.closest( '.collapsible-text' ).classList.toggle( 'expanded' );
+const toggleCollapsibleArea = ( { currentTarget } ) => {
+	const expanded = currentTarget.closest( '.collapsible-text' ).classList.toggle( 'expanded' );
+	if ( ! expanded ) {
+		currentTarget.scrollIntoView( { block: 'center' } );
+	}
+};
 
 /**
  * Attach listeners to any collapsible area triggers.


### PR DESCRIPTION
Addresses the issue noted in https://github.com/humanmade/wikimedia/issues/661

Will need a submodule update in the Sound Logo project after merge.