### PR TITLE
#704: Allow interacting with collapsible text content.

### DIFF
--- a/assets/src/sass/blocks/_collapsible-text.scss
+++ b/assets/src/sass/blocks/_collapsible-text.scss
@@ -16,6 +16,7 @@
 			bottom: 0;
 			content: "";
 			height: 100%;
+			pointer-events: none;
 			position: absolute;
 			transition: opacity 500ms linear;
 			width: 100%;


### PR DESCRIPTION
The expanded "collapsible text" block is covered by a hidden generated content pseudo-element use to animate the overlay gradient. This overlay needed a pointer-events:none declaration in order to allow visitors to click on links within it.

See https://github.com/humanmade/wikimedia/issues/704

Will require a submodule update in the Sound Logo codebase after merging.